### PR TITLE
Add prerelease tag to the support matrix

### DIFF
--- a/.github/actions/install_npm_package/action.yml
+++ b/.github/actions/install_npm_package/action.yml
@@ -7,6 +7,9 @@ inputs:
   working-directory:
     description: "Relative path to the directory where package should be installed"
     required: true
+  legacy_npm_peers:
+    description: "Flag indicating need to use legacy-npm-peers flags during install"
+    required: false
   version:
     description: "Install version specified in input"
     required: false

--- a/.github/actions/install_npm_package/dist/index.js
+++ b/.github/actions/install_npm_package/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 795:
+/***/ 262:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(37));
-const utils_1 = __nccwpck_require__(9);
+const utils_1 = __nccwpck_require__(81);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 810:
+/***/ 579:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(795);
-const file_command_1 = __nccwpck_require__(450);
-const utils_1 = __nccwpck_require__(9);
+const command_1 = __nccwpck_require__(262);
+const file_command_1 = __nccwpck_require__(993);
+const utils_1 = __nccwpck_require__(81);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
-const oidc_utils_1 = __nccwpck_require__(486);
+const oidc_utils_1 = __nccwpck_require__(717);
 /**
  * The code to exit an action
  */
@@ -425,17 +425,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(119);
+var summary_1 = __nccwpck_require__(797);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(119);
+var summary_2 = __nccwpck_require__(797);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(310);
+var path_utils_1 = __nccwpck_require__(525);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -443,7 +443,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 450:
+/***/ 993:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -474,8 +474,8 @@ exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(147));
 const os = __importStar(__nccwpck_require__(37));
-const uuid_1 = __nccwpck_require__(542);
-const utils_1 = __nccwpck_require__(9);
+const uuid_1 = __nccwpck_require__(832);
+const utils_1 = __nccwpck_require__(81);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -508,7 +508,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 486:
+/***/ 717:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -524,9 +524,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(493);
-const auth_1 = __nccwpck_require__(161);
-const core_1 = __nccwpck_require__(810);
+const http_client_1 = __nccwpck_require__(795);
+const auth_1 = __nccwpck_require__(981);
+const core_1 = __nccwpck_require__(579);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -592,7 +592,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 310:
+/***/ 525:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -657,7 +657,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 119:
+/***/ 797:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -947,7 +947,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 9:
+/***/ 81:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -994,7 +994,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 161:
+/***/ 981:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1082,7 +1082,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 493:
+/***/ 795:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1120,8 +1120,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
 const http = __importStar(__nccwpck_require__(685));
 const https = __importStar(__nccwpck_require__(687));
-const pm = __importStar(__nccwpck_require__(906));
-const tunnel = __importStar(__nccwpck_require__(387));
+const pm = __importStar(__nccwpck_require__(725));
+const tunnel = __importStar(__nccwpck_require__(848));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -1694,7 +1694,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 906:
+/***/ 725:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1762,15 +1762,15 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 387:
+/***/ 848:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(585);
+module.exports = __nccwpck_require__(295);
 
 
 /***/ }),
 
-/***/ 585:
+/***/ 295:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2042,7 +2042,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 542:
+/***/ 832:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2106,29 +2106,29 @@ Object.defineProperty(exports, "parse", ({
   }
 }));
 
-var _v = _interopRequireDefault(__nccwpck_require__(537));
+var _v = _interopRequireDefault(__nccwpck_require__(135));
 
-var _v2 = _interopRequireDefault(__nccwpck_require__(76));
+var _v2 = _interopRequireDefault(__nccwpck_require__(418));
 
-var _v3 = _interopRequireDefault(__nccwpck_require__(749));
+var _v3 = _interopRequireDefault(__nccwpck_require__(611));
 
-var _v4 = _interopRequireDefault(__nccwpck_require__(166));
+var _v4 = _interopRequireDefault(__nccwpck_require__(732));
 
-var _nil = _interopRequireDefault(__nccwpck_require__(505));
+var _nil = _interopRequireDefault(__nccwpck_require__(910));
 
-var _version = _interopRequireDefault(__nccwpck_require__(897));
+var _version = _interopRequireDefault(__nccwpck_require__(419));
 
-var _validate = _interopRequireDefault(__nccwpck_require__(785));
+var _validate = _interopRequireDefault(__nccwpck_require__(436));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(1));
+var _stringify = _interopRequireDefault(__nccwpck_require__(843));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(993));
+var _parse = _interopRequireDefault(__nccwpck_require__(353));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
 
-/***/ 589:
+/***/ 496:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2158,7 +2158,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 505:
+/***/ 910:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2173,7 +2173,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 993:
+/***/ 353:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2184,7 +2184,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(785));
+var _validate = _interopRequireDefault(__nccwpck_require__(436));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2225,7 +2225,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 459:
+/***/ 821:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2240,7 +2240,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 779:
+/***/ 346:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2271,7 +2271,7 @@ function rng() {
 
 /***/ }),
 
-/***/ 956:
+/***/ 762:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2301,7 +2301,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 1:
+/***/ 843:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2312,7 +2312,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(785));
+var _validate = _interopRequireDefault(__nccwpck_require__(436));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2347,7 +2347,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 537:
+/***/ 135:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2358,9 +2358,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(779));
+var _rng = _interopRequireDefault(__nccwpck_require__(346));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(1));
+var _stringify = _interopRequireDefault(__nccwpck_require__(843));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2461,7 +2461,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 76:
+/***/ 418:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2472,9 +2472,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(469));
+var _v = _interopRequireDefault(__nccwpck_require__(461));
 
-var _md = _interopRequireDefault(__nccwpck_require__(589));
+var _md = _interopRequireDefault(__nccwpck_require__(496));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2484,7 +2484,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 469:
+/***/ 461:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2496,9 +2496,9 @@ Object.defineProperty(exports, "__esModule", ({
 exports["default"] = _default;
 exports.URL = exports.DNS = void 0;
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(1));
+var _stringify = _interopRequireDefault(__nccwpck_require__(843));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(993));
+var _parse = _interopRequireDefault(__nccwpck_require__(353));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2569,7 +2569,7 @@ function _default(name, version, hashfunc) {
 
 /***/ }),
 
-/***/ 749:
+/***/ 611:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2580,9 +2580,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(779));
+var _rng = _interopRequireDefault(__nccwpck_require__(346));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(1));
+var _stringify = _interopRequireDefault(__nccwpck_require__(843));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2613,7 +2613,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 166:
+/***/ 732:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2624,9 +2624,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(469));
+var _v = _interopRequireDefault(__nccwpck_require__(461));
 
-var _sha = _interopRequireDefault(__nccwpck_require__(956));
+var _sha = _interopRequireDefault(__nccwpck_require__(762));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2636,7 +2636,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 785:
+/***/ 436:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2647,7 +2647,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _regex = _interopRequireDefault(__nccwpck_require__(459));
+var _regex = _interopRequireDefault(__nccwpck_require__(821));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2660,7 +2660,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 897:
+/***/ 419:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2671,7 +2671,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(785));
+var _validate = _interopRequireDefault(__nccwpck_require__(436));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2688,23 +2688,25 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 517:
+/***/ 790:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const {shellCommand} = __nccwpck_require__(222);
+const {shellCommand} = __nccwpck_require__(349);
 
 
-    function install({source, version, packageName, cwd}) {
+    function install({source, version, packageName, legacyNpmPeers, cwd}) {
         switch (source) {
             case "remote":
-                return remote({version, packageName, cwd})
+                return remote({version, packageName, legacyNpmPeers, cwd})
             default:
                 throw new Error(`Installer doesn't support installation from ${source}`)
         }
     }
 
-    function remote({version, packageName, cwd}) {
-        shellCommand(`npm install ${packageName}@${version}`, cwd)
+    function remote({version, packageName, legacyNpmPeers, cwd}) {
+        let command = `npm install ${packageName}@${version}`
+        if (legacyNpmPeers) command += ' --legacy-peer-deps'
+        shellCommand(command, cwd)
         const ls = shellCommand(`npm list`, cwd)
         const regResult = new RegExp(` (${packageName})@(.*)`).exec(ls)
         return {installed_name: regResult[1], installed_version: regResult[2]}
@@ -2718,11 +2720,11 @@ module.exports = install
 
 /***/ }),
 
-/***/ 197:
+/***/ 167:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const CoreParser = __nccwpck_require__(649)
-const {shellCommand} = __nccwpck_require__(222);
+const CoreParser = __nccwpck_require__(189)
+const {shellCommand} = __nccwpck_require__(349);
 
 class JSParser extends CoreParser {
 
@@ -2756,10 +2758,10 @@ module.exports = JSParser
 
 /***/ }),
 
-/***/ 222:
+/***/ 349:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const {execSync} = __nccwpck_require__(81)
+const {execSync} = __nccwpck_require__(493)
 
 function checkInput(str) {
     return str && str.length > 0 ? strToNum(str) : str;
@@ -2786,13 +2788,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 649:
+/***/ 189:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const {strToNum} = __nccwpck_require__(222)
-const Version = __nccwpck_require__(676);
+const {strToNum} = __nccwpck_require__(349)
+const Version = __nccwpck_require__(517);
 
 
 class CoreParser {
@@ -2895,10 +2897,10 @@ module.exports = CoreParser
 
 /***/ }),
 
-/***/ 676:
+/***/ 517:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const {strToNum} = __nccwpck_require__(222);
+const {strToNum} = __nccwpck_require__(349);
 
 class Version {
     constructor({major, minor, patch}) {
@@ -2938,7 +2940,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 81:
+/***/ 493:
 /***/ ((module) => {
 
 "use strict";
@@ -3067,10 +3069,10 @@ module.exports = require("util");
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = __nccwpck_require__(810)
+const core = __nccwpck_require__(579)
 const path = __nccwpck_require__(17)
-const JSParser = __nccwpck_require__(197);
-const install = __nccwpck_require__(517);
+const JSParser = __nccwpck_require__(167);
+const install = __nccwpck_require__(790);
 
 try {
     const packageName = core.getInput('package');
@@ -3078,12 +3080,13 @@ try {
     const cwd = path.join(process.cwd(), dir)
     const parser = new JSParser();
     const inputVersion = core.getInput("version")
+    const legacyNpmPeers = core.getInput("legacy_npm_peers")
     const {source, version} = parser.parseInputVersion({version:inputVersion, packageName, cwd})
     console.log(`Package name: ${packageName} | type: ${typeof packageName}`)
     console.log(`Dir: ${dir} | type: ${typeof dir}`)
     console.log(version)
     console.log(cwd)
-    const {installed_name, installed_version} = install({source, version, packageName, cwd});
+    const {installed_name, installed_version} = install({source, version, packageName, legacyNpmPeers, cwd});
     const time = (new Date()).toTimeString();
     core.setOutput("time", time);
     core.setOutput("package_version", installed_version)

--- a/.github/actions/install_npm_package/index.js
+++ b/.github/actions/install_npm_package/index.js
@@ -9,12 +9,13 @@ try {
     const cwd = path.join(process.cwd(), dir)
     const parser = new JSParser();
     const inputVersion = core.getInput("version")
+    const legacyNpmPeers = core.getInput("legacy_npm_peers")
     const {source, version} = parser.parseInputVersion({version:inputVersion, packageName, cwd})
     console.log(`Package name: ${packageName} | type: ${typeof packageName}`)
     console.log(`Dir: ${dir} | type: ${typeof dir}`)
     console.log(version)
     console.log(cwd)
-    const {installed_name, installed_version} = install({source, version, packageName, cwd});
+    const {installed_name, installed_version} = install({source, version, packageName, legacyNpmPeers, cwd});
     const time = (new Date()).toTimeString();
     core.setOutput("time", time);
     core.setOutput("package_version", installed_version)

--- a/.github/actions/install_npm_package/src/JSInstall.js
+++ b/.github/actions/install_npm_package/src/JSInstall.js
@@ -1,17 +1,19 @@
 const {shellCommand} = require("../../util/common");
 
 
-    function install({source, version, packageName, cwd}) {
+    function install({source, version, packageName, legacyNpmPeers, cwd}) {
         switch (source) {
             case "remote":
-                return remote({version, packageName, cwd})
+                return remote({version, packageName, legacyNpmPeers, cwd})
             default:
                 throw new Error(`Installer doesn't support installation from ${source}`)
         }
     }
 
-    function remote({version, packageName, cwd}) {
-        shellCommand(`npm install ${packageName}@${version}`, cwd)
+    function remote({version, packageName, legacyNpmPeers, cwd}) {
+        let command = `npm install ${packageName}@${version}`
+        if (legacyNpmPeers) command += ' --legacy-peer-deps'
+        shellCommand(command, cwd)
         const ls = shellCommand(`npm list`, cwd)
         const regResult = new RegExp(` (${packageName})@(.*)`).exec(ls)
         return {installed_name: regResult[1], installed_version: regResult[2]}

--- a/.github/actions/test_js/action.yml
+++ b/.github/actions/test_js/action.yml
@@ -26,6 +26,7 @@ runs:
         package: ${{matrix.framework_package}}
         version: ${{matrix.version}}
         working-directory: ${{matrix.work_dir}}
+        legacy_npm_peers: ${{matrix.legacy_npm_peers }}
     - name: Eyes SDK js package install
       id: eyes
       uses: ./.github/actions/install_npm_package
@@ -33,6 +34,7 @@ runs:
         package: ${{matrix.eyes_package}}
         version: ${{inputs.eyes_version}}
         working-directory: ${{matrix.work_dir}}
+        legacy_npm_peers: ${{matrix.legacy_npm_peers }}
     - name: Log extra info
       id: logging
       uses: ./.github/actions/chrome_version

--- a/sdks/js/eyes-nightwatch/config/matrix.conf.js
+++ b/sdks/js/eyes-nightwatch/config/matrix.conf.js
@@ -28,6 +28,7 @@ const variations = base_common
         version: 'exact@1.7.13',
         selenium_legacy: true,
         test_command: "npm run nightwatch1 && USE_UFG=true npm run nightwatch1"})))
+    .concat([{...common, os: "ubuntu-latest", version: "exact@alpha"}])
     .map(variant => ({...variant, job_name:`JS Nightwatch [${variant.os} | ${common["node-version"]}] version: ${variant.version}`}))
 console.log(variations)
 module.exports = {

--- a/sdks/js/eyes-nightwatch/config/matrix.conf.js
+++ b/sdks/js/eyes-nightwatch/config/matrix.conf.js
@@ -28,7 +28,7 @@ const variations = base_common
         version: 'exact@1.7.13',
         selenium_legacy: true,
         test_command: "npm run nightwatch1 && USE_UFG=true npm run nightwatch1"})))
-    .concat([{...common, os: "ubuntu-latest", version: "exact@alpha"}])
+    .concat([{...common, os: "ubuntu-latest", version: "exact@alpha", legacy_npm_peers: true}])
     .map(variant => ({...variant, job_name:`JS Nightwatch [${variant.os} | ${common["node-version"]}] version: ${variant.version}`}))
 console.log(variations)
 module.exports = {

--- a/sdks/js/eyes-playwright/config/matrix.conf.js
+++ b/sdks/js/eyes-playwright/config/matrix.conf.js
@@ -14,6 +14,7 @@ const base_variations = [
     {
         "os": "ubuntu-latest",
         "version": "exact@next",
+        legacy_npm_peers: true,
     },
     {
         "os": "ubuntu-latest",

--- a/sdks/js/eyes-playwright/config/matrix.conf.js
+++ b/sdks/js/eyes-playwright/config/matrix.conf.js
@@ -13,6 +13,10 @@ const base_variations = [
     },
     {
         "os": "ubuntu-latest",
+        "version": "exact@next",
+    },
+    {
+        "os": "ubuntu-latest",
         "version": "minor@1",
     },
     {

--- a/sdks/js/eyes-storybook/config/matrix.conf.js
+++ b/sdks/js/eyes-storybook/config/matrix.conf.js
@@ -14,6 +14,12 @@ const base_variations = [
     },
     {
         "work_dir": "sdks/js/eyes-storybook/latest",
+        "os": "ubuntu-latest",
+        "version": "exact@future",
+        "branch": "latest-story"
+    },
+    {
+        "work_dir": "sdks/js/eyes-storybook/latest",
         "os": "windows-latest",
         "version": "latest@",
         "branch": "latest-story"


### PR DESCRIPTION
packages added 
playwright 
nightwatch
storybook 

skipped 
cypress: release flow for cypress doesn't have big time difference between dev and latest release so there is no point testing it out. For the most support matrix run those version would be the same. 
wdio: currently doesn't have active tag for the prereleased versions.